### PR TITLE
derive host and port from full url, better for backend services

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -9,4 +9,3 @@ requires 'Dancer', '1.3123';
 requires 'Catmandu', '>=0.8014';
 requires 'Catmandu::Exporter::Template', '0.03';
 requires 'SRU', '1.01';
-requires 'URI','0';

--- a/cpanfile
+++ b/cpanfile
@@ -9,3 +9,4 @@ requires 'Dancer', '1.3123';
 requires 'Catmandu', '>=0.8014';
 requires 'Catmandu::Exporter::Template', '0.03';
 requires 'SRU', '1.01';
+requires 'URI','0';

--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -17,6 +17,7 @@ use Catmandu::Fix;
 use Catmandu::Exporter::Template;
 use SRU::Request;
 use SRU::Response;
+use URI::URL;
 
 sub sru_provider {
     my ($path) = @_;
@@ -87,8 +88,9 @@ sub sru_provider {
 
             my $transport   = request->scheme;
             my $database    = substr request->path, 1;
-            my $host        = request->host; $host =~ s/:.+//;
-            my $port        = request->port;
+            my $uri         = URI::URL->new( request->uri_for( request->path_info() ) );
+            my $host        = $uri->host;
+            my $port        = $uri->port;
             $response->record(SRU::Response::Record->new(
                 recordSchema => 'http://explain.z3950.org/dtd/2.1/',
                 recordData   => <<XML,

--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -17,7 +17,6 @@ use Catmandu::Fix;
 use Catmandu::Exporter::Template;
 use SRU::Request;
 use SRU::Response;
-use URI::URL;
 
 sub sru_provider {
     my ($path) = @_;
@@ -88,7 +87,7 @@ sub sru_provider {
 
             my $transport   = request->scheme;
             my $database    = substr request->path, 1;
-            my $uri         = URI::URL->new( request->uri_for( request->path_info() ) );
+            my $uri         = request->uri_for( request->path_info() );
             my $host        = $uri->host;
             my $port        = $uri->port;
             $response->record(SRU::Response::Record->new(


### PR DESCRIPTION
request->host and request->port deliver host and port of backend service,
not of the frontend service.

Plack::Middleware::ReverseProxy fixes this issue, but has no clue of the original frontend prefix (e.g. "/sru"), so all links still get lost in translation.
Dancer::Middleware::Rebase fixes the path prefix, but does nothing to reset host and port.

This should serve both
