### PR TITLE
param maximumRecords can be 0

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -132,8 +132,8 @@ XML
                 $cql = "( $setting->{cql_filter}) and ( $cql)";
             }
 
-            my $first = $request->startRecord || 1;
-            my $limit = is_natural( $request->maximumRecords ) ? $request->maximumRecords : $default_limit;
+            my $first = $request->startRecord // 1;
+            my $limit = $request->maximumRecords // $default_limit;
             if ($limit > $maximum_limit) {
                 $limit = $maximum_limit;
             }

--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -133,7 +133,7 @@ XML
             }
 
             my $first = $request->startRecord || 1;
-            my $limit = $request->maximumRecords || $default_limit;
+            my $limit = is_natural( $request->maximumRecords ) ? $request->maximumRecords : $default_limit;
             if ($limit > $maximum_limit) {
                 $limit = $maximum_limit;
             }


### PR DESCRIPTION
The parameter maximumRecords can be 0 (handy to check number of records).
In the current version 0 evaluates to "false", and is replaced by the default limit.