### PR TITLE
Fix Explain schema URL and validation

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -94,10 +94,10 @@ sub sru_provider {
             my $host        = $uri->host;
             my $port        = $uri->port;
             $response->record(SRU::Response::Record->new(
-                recordSchema => 'http://explain.z3950.org/dtd/2.1/',
+                recordSchema => 'http://explain.z3950.org/dtd/2.0/',
                 recordData   => <<XML,
-<explain xmlns="http://explain.z3950.org/dtd/2.1/">
-<serverInfo protocol="SRU" method="GET" transport="$transport">
+<explain xmlns="http://explain.z3950.org/dtd/2.0/">
+<serverInfo protocol="SRU" transport="$transport">
 <host>$host</host>
 <port>$port</port>
 <database>$database</database>


### PR DESCRIPTION
Hi. From what I can see, the latest published version of the Explain schema is 2.0:

http://explain.z3950.org/dtd/

I wonder if 2.1 could be an error that has propagated from http://www.loc.gov/standards/sru/explain/ , since they use version 2.1 in the example there, yet the link they provide in the same document goes to version 2.0, and they also use version 2.0 in their own SRU service at http://lx2.loc.gov:210/lcdb?version=1.1&operation=explain

Also, the `method` attribute, while included in the example http://www.loc.gov/standards/sru/explain/, is actually not allowed by version 2.0 of the schema. Which makes me ponder if perhaps there was a draft version 2.1 prepared at some point, which added the `method` argument. But I couldn't find any information about that. I sent LC an e-mail to check, but in any case I think it's probably better to use version 2.0.
