### PR TITLE
Make all settings overridable during initialization

### DIFF
--- a/lib/Dancer/Plugin/Catmandu/SRU.pm
+++ b/lib/Dancer/Plugin/Catmandu/SRU.pm
@@ -16,11 +16,16 @@ use SRU::Request;
 use SRU::Response;
 use Dancer qw(:syntax);
 use Dancer::Plugin;
+use Clone qw(clone);
 
 sub sru_provider {
-    my ($path) = @_;
+    my ($path, %opts) = @_;
 
-    my $setting = plugin_setting;
+    my $setting = clone(plugin_setting);
+
+    foreach my $key (keys %opts) {
+        $setting->{$key} = $opts{$key};
+    }
 
     my $content_type = $setting->{content_type} // 'text/xml';
 


### PR DESCRIPTION
This allows all settings to be configured per instance.

Related: https://github.com/LibreCat/Dancer-Plugin-Catmandu-OAI/pull/24

Note: I added `clone` to align with the OAI plugin. I'm not very familiar with Perl though, so I don't know what's best pratice when it comes to things like this.